### PR TITLE
Emphasize permitted version format in packages for publication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,6 +292,15 @@ the tag.
 For Git projects, the version relies on `git describe <https://git-scm.com/docs/git-describe>`_,
 so you will see an additional ``g`` prepended to the ``{revision hash}``.
 
+.. note::
+
+    According to `PEP 440 <https://peps.python.org/pep-0440/#local-version-identifiers>`_,
+    if a version includes a local component, the package cannot be published to public
+    package indexes like PyPI or TestPyPI. The disallowed version segments may
+    be seen in auto-publishing workflows or when a configuration mistake is made.
+
+    However, some package indexes such as devpi or other alternatives allow local
+    versions. Local version identifiers must comply with PEP `PEP 440`_.
 
 Semantic Versioning (SemVer)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ so you will see an additional ``g`` prepended to the ``{revision hash}``.
     be seen in auto-publishing workflows or when a configuration mistake is made.
 
     However, some package indexes such as devpi or other alternatives allow local
-    versions. Local version identifiers must comply with PEP `PEP 440`_.
+    versions. Local version identifiers must comply with `PEP 440`_.
 
 Semantic Versioning (SemVer)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The patch adds mention in README that local version identifiers in packages don’t allow publishing to PyPI/TestPyPI. Also, it suggests alternative local servers for using local version identifiers.

Resolves #322